### PR TITLE
Added zip_strict option

### DIFF
--- a/parametrized.py
+++ b/parametrized.py
@@ -26,4 +26,5 @@ def fixture(*params, **kwargs):
 
 parametrized.fixture = fixture
 parametrized.zip = partial(parametrized, combine=zip)
+parametrized.zip_strict = partial(parametrized, combine=partial(zip, strict=True))
 parametrized.product = partial(parametrized, combine=itertools.product)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import pytest
 from parametrized import parametrized
 
@@ -40,3 +42,23 @@ def test_error(name='abc', value=range(3)):
 @parametrized.product
 def test_param(key=[0], value=[0, pytest.param(1, marks=pytest.mark.xfail())]):
     assert key == value
+
+
+def test_zip_strict_error(tmp_path, capsys):
+    unrunnable_test_file = tmp_path / "test_zip_strict_error.py"
+
+    unrunnable_test_file.write_text(
+        dedent(
+            """
+            from parametrized import parametrized
+
+            @parametrized.zip_strict
+            def test_zip_strict_error(name='abc', value=range(4)):
+                pass
+            """
+        ).lstrip()
+    )
+
+    exit_code = pytest.main([str(unrunnable_test_file)])
+    assert exit_code == pytest.ExitCode.INTERRUPTED
+    assert "ValueError: zip() argument 2 is shorter than argument 1" in capsys.readouterr().out


### PR DESCRIPTION
Hi,

Nice addon, I really like the way this cuts down on boilerplate in pytests!

In my organization though we enforce strict zips because otherwise the test will silently miss when some items are longer than others - if you add a new test case to the end of each default but forget one, then your new test case is never run.

To address this I propose adding`parametrized.zip_strict`, which will prevent pytest from running at all if the test cases are of uneven length. As you can see I've had to adopt a slightly convoluted way of testing it because things like `pytest.mark.xfail` don't work; nor does having a decorated enclosure (because pytest doesn't ever run it, so it remains as a `zip` object that never raises its error); nor can you inspect the `zip` object to see if it has `strict=True` set.

Happy to take feedback or suggestions.